### PR TITLE
Fix field mappings for Solr and new unit test

### DIFF
--- a/solr/src/test/java/com/digitalpebble/behemoth/solr/TestSOLRWriter.java
+++ b/solr/src/test/java/com/digitalpebble/behemoth/solr/TestSOLRWriter.java
@@ -1,0 +1,31 @@
+package com.digitalpebble.behemoth.solr;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.IOException;
+import org.junit.Test;
+import org.apache.hadoop.mapred.JobConf;
+
+public class TestSOLRWriter {
+  @Test
+  public void testFieldMappings() throws IOException {
+    JobConf conf = new JobConf();
+    conf.set("solr.server.url", "http://example.org");
+    conf.set("solr.f.person", "Person.string");
+    conf.set("solr.f.personTitle", "Person.title");
+    conf.set("solr.f.location", "Location");
+
+    SOLRWriter writer = new SOLRWriter();
+    writer.open(conf, "test");
+
+    assertEquals(writer.fieldMapping.size(), 2);
+    assertNotNull(writer.fieldMapping.get("Person"));
+    assertEquals(writer.fieldMapping.get("Person").size(), 2);
+    assertEquals(writer.fieldMapping.get("Person").get("string"), "person");
+    assertEquals(writer.fieldMapping.get("Person").get("title"), "personTitle");
+    assertNotNull(writer.fieldMapping.get("Location"));
+    assertEquals(writer.fieldMapping.get("Location").size(), 1);
+    assertEquals(writer.fieldMapping.get("Location").get("*"), "location");
+  }
+}


### PR DESCRIPTION
Greeings, Julien

My name is David Arthur, I'm working with Grant on some projects that involve Behemoth. I ran into an issue yesterday around mapping Behemoth annotations to Solr.

There was a bug with the field mappings. It was using <annotation>.<feature> as
the key in the map and therefor not matching any annotations during the loop
later on.

Also, changed `setField` to `addField` to allow for multi-valued Solr fields.

Added a unit test for the field mappings as well.

Let me know if you have any questions.

Cheers
