### PR TITLE
Upgrade to Mahout 0.10.0 #54

### DIFF
--- a/mahout/pom.xml
+++ b/mahout/pom.xml
@@ -59,8 +59,8 @@
 
 		<dependency>
 			<groupId>org.apache.mahout</groupId>
-			<artifactId>mahout-core</artifactId>
-			<version>0.9</version>
+			<artifactId>mahout-mr</artifactId>
+			<version>0.10.0</version>
 		</dependency>
 
 	</dependencies>


### PR DESCRIPTION
@jnioche you were right on this one.
I've noticed that Hadoop API shows up as being deprecated now so this patch, if and once merged could do with some extensive testing.
I'm dockerizing Behemoth with Hadoop 1.2.1 and Mahout 0.10.0 right now so hopefully any issues will come out from that.