### PR TITLE
Make Annotation's serializable and initial implementation of adding annotations to the Exporter output

### DIFF
--- a/core/src/main/java/com/digitalpebble/behemoth/Annotation.java
+++ b/core/src/main/java/com/digitalpebble/behemoth/Annotation.java
@@ -17,6 +17,7 @@
 
 package com.digitalpebble.behemoth;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -25,7 +26,12 @@ import java.util.Map;
  * Implementation of an Annotation. Has a type , metadata and start and end
  * offsets referring to the position in the text of a @class BehemothDocument.
  **/
-public class Annotation implements Comparable<Annotation> {
+public class Annotation implements Comparable<Annotation>, Serializable {
+
+  /**
+   * 
+   */
+  private static final long serialVersionUID = 1L;
 
     private String type;
 

--- a/core/src/main/java/com/digitalpebble/behemoth/util/AnnotationsUtil.java
+++ b/core/src/main/java/com/digitalpebble/behemoth/util/AnnotationsUtil.java
@@ -21,13 +21,13 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
 
 import com.digitalpebble.behemoth.Annotation;
 
 public class AnnotationsUtil {
 
     /** Sort the annotations by startOffset **/
+    @SuppressWarnings("unchecked")
     public static void sort(List<Annotation> input) {
         Collections.sort(input, new AnnotationComparator());
     }

--- a/core/src/main/java/com/digitalpebble/behemoth/util/ContentExtractor.java
+++ b/core/src/main/java/com/digitalpebble/behemoth/util/ContentExtractor.java
@@ -17,8 +17,15 @@
 
 package com.digitalpebble.behemoth.util;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.ObjectOutputStream;
 import java.net.URLEncoder;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
 import java.util.UUID;
 
 import org.apache.commons.cli.CommandLine;
@@ -31,6 +38,7 @@ import org.apache.commons.compress.archivers.ArchiveException;
 import org.apache.commons.compress.archivers.ArchiveOutputStream;
 import org.apache.commons.compress.archivers.ArchiveStreamFactory;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.lang.ArrayUtils;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
@@ -44,6 +52,7 @@ import org.apache.hadoop.util.ToolRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.digitalpebble.behemoth.Annotation;
 import com.digitalpebble.behemoth.BehemothConfiguration;
 import com.digitalpebble.behemoth.BehemothDocument;
 import com.digitalpebble.behemoth.DocumentFilter;
@@ -74,6 +83,8 @@ public class ContentExtractor extends Configured implements Tool {
 
     // dump the text otherwise
     private boolean dumpBinary = false;
+    // don't dump annotations by default
+    private boolean dumpAnnotations = false;
 
     private ArchiveOutputStream currentArchive = null;
 
@@ -107,6 +118,7 @@ public class ContentExtractor extends Configured implements Tool {
                 "dumps binary content, text otherwise");
         options.addOption("n", "filenaming", true,
                 "whether to name files based on URL, UUID (default) or NUM");
+        options.addOption("a", "annotation", false, "whether to include annotation in output (off by default)");
 
         // parse the command line arguments
         try {
@@ -122,6 +134,7 @@ public class ContentExtractor extends Configured implements Tool {
                 return -1;
             }
             dumpBinary = line.hasOption("binary");
+            dumpAnnotations = line.hasOption("annotation");
 
             if (line.hasOption("filenaming")) {
                 String naming = line.getOptionValue("n");
@@ -203,6 +216,7 @@ public class ContentExtractor extends Configured implements Tool {
         numEntriesInCurrentArchive++;
         currentArchive.putArchiveEntry(new ZipArchiveEntry(fileName));
         currentArchive.write(content);
+        LOG.debug("Successfully wrote BehemothDocument 'content' to output.");
         currentArchive.closeArchiveEntry();
         index.flush();
         if (numEntriesInCurrentArchive == maxNumEntriesInArchive) {
@@ -250,11 +264,32 @@ public class ContentExtractor extends Configured implements Tool {
                     fileName += ".txt";
 
                 byte[] contentBytes;
-                if (dumpBinary)
+                List<Annotation> annots = null;
+                if (dumpBinary) {
                     contentBytes = inputDoc.getContent();
-                else
+                    if(dumpAnnotations) {
+                        annots = inputDoc.getAnnotations();
+                        //write annotations with content?
+                        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                        ObjectOutputStream oos = new ObjectOutputStream(bos);
+                        oos.writeObject(annots);
+                        byte[] annotsBytes = bos.toByteArray();
+                        contentBytes = concatAndDeepClone(contentBytes, annotsBytes);
+                    }
+                } else {
                     contentBytes = inputDoc.getText().getBytes("UTF-8");
-                // out.write(contentBytes, 0, contentBytes.length);
+                    if(dumpAnnotations) {
+                        annots = inputDoc.getAnnotations();
+                        ArrayList<String> annotsArrayList = new ArrayList<String>();
+                        for (int i = 0; i < annots.size(); i++) {
+                          annotsArrayList.add(annots.get(i).toString());
+                        }
+                        
+                        byte[] annotsBytes = annotsArrayList.toString().getBytes(Charset.forName("UTF-8"));
+                        contentBytes = concatAndDeepClone(contentBytes, annotsBytes);
+                    }
+                }
+                
                 addToArchive(fileName, contentBytes, dir);
 
                 // add the mapping URL->filename in the index -> archive num
@@ -263,5 +298,11 @@ public class ContentExtractor extends Configured implements Tool {
             }
             current.close();
         }
+    }
+    
+    private byte[] concatAndDeepClone(byte[] contentBytes, byte[] annotsBytes) {
+      byte[] concatBytes = ArrayUtils.addAll(contentBytes, annotsBytes);
+      contentBytes = concatBytes.clone();
+      return contentBytes;
     }
 }


### PR DESCRIPTION
Hi @jnioche ,
Please see the patch below which does the following
* makes Annotation’s serializable, meaning we can export them alongside document text as either binary or textual content.
* implements the command line boolean flag for facilitating the above
* implements the core logic for exporting Annotations as string values, comma separated
* concatenates both textual content and annotations, then deep clones the object and returns it for exporting.

An issue is that the concatenation is not a join. 
What do you think about the patch. Is it worthy of inclusion into Behemoth?