### PR TITLE
squid:S1192 - String literals should not be duplicated

### DIFF
--- a/core/src/main/java/com/digitalpebble/behemoth/util/ContentExtractor.java
+++ b/core/src/main/java/com/digitalpebble/behemoth/util/ContentExtractor.java
@@ -56,7 +56,8 @@ public class ContentExtractor extends Configured implements Tool {
     private static final Logger LOG = LoggerFactory
             .getLogger(ContentExtractor.class);
 
-    public static final String numEntriesPerArchiveParamName = "numEntriesPerArchive";
+    private static final String numEntriesPerArchiveParamName = "numEntriesPerArchive";
+    private static final String CONTENT_EXTRACTOR = "ContentExtractor";
 
     public enum FileNamingMode {
         URL, UUID, NUM;
@@ -114,11 +115,11 @@ public class ContentExtractor extends Configured implements Tool {
             String input = line.getOptionValue("i");
             String output = line.getOptionValue("o");
             if (line.hasOption("help")) {
-                formatter.printHelp("ContentExtractor", options);
+                formatter.printHelp(CONTENT_EXTRACTOR, options);
                 return 0;
             }
             if (input == null || output == null) {
-                formatter.printHelp("ContentExtractor", options);
+                formatter.printHelp(CONTENT_EXTRACTOR, options);
                 return -1;
             }
             dumpBinary = line.hasOption("binary");
@@ -131,7 +132,7 @@ public class ContentExtractor extends Configured implements Tool {
             return generateDocs(input, output);
 
         } catch (ParseException e) {
-            formatter.printHelp("ContentExtractor", options);
+            formatter.printHelp(CONTENT_EXTRACTOR, options);
             return -1;
         }
     }

--- a/core/src/main/java/com/digitalpebble/behemoth/util/CorpusFilter.java
+++ b/core/src/main/java/com/digitalpebble/behemoth/util/CorpusFilter.java
@@ -47,6 +47,8 @@ import com.digitalpebble.behemoth.BehemothMapper;
  **/
 public class CorpusFilter extends Configured implements Tool {
 
+    private static final String CORPUS_FILTER = "CorpusFilter";
+
     public static void main(String[] args) throws Exception {
         int res = ToolRunner.run(BehemothConfiguration.create(),
                 new CorpusFilter(), args);
@@ -72,15 +74,15 @@ public class CorpusFilter extends Configured implements Tool {
             String input = line.getOptionValue("i");
             String output = line.getOptionValue("o");
             if (line.hasOption("help")) {
-                formatter.printHelp("CorpusFilter", options);
+                formatter.printHelp(CORPUS_FILTER, options);
                 return 0;
             }
             if (input == null | output == null) {
-                formatter.printHelp("CorpusFilter", options);
+                formatter.printHelp(CORPUS_FILTER, options);
                 return -1;
             }
         } catch (ParseException e) {
-            formatter.printHelp("CorpusFilter", options);
+            formatter.printHelp(CORPUS_FILTER, options);
         }
 
         final FileSystem fs = FileSystem.get(getConf());

--- a/core/src/main/java/com/digitalpebble/behemoth/util/CorpusGenerator.java
+++ b/core/src/main/java/com/digitalpebble/behemoth/util/CorpusGenerator.java
@@ -62,6 +62,7 @@ import com.digitalpebble.behemoth.BehemothDocument;
  */
 
 public class CorpusGenerator extends Configured implements Tool {
+    private static final String CORPUS_GENERATOR = "CorpusGenerator";
     private transient static Logger log = LoggerFactory
             .getLogger(CorpusGenerator.class);
     private Path input, output;
@@ -151,19 +152,19 @@ public class CorpusGenerator extends Configured implements Tool {
         try {
             line = parser.parse(options, args);
             if (line.hasOption("help")) {
-                formatter.printHelp("CorpusGenerator", options);
+                formatter.printHelp(CORPUS_GENERATOR, options);
                 return 0;
             }
             if (!line.hasOption("i")) {
-                formatter.printHelp("CorpusGenerator", options);
+                formatter.printHelp(CORPUS_GENERATOR, options);
                 return -1;
             }
             if (!line.hasOption("o")) {
-                formatter.printHelp("CorpusGenerator", options);
+                formatter.printHelp(CORPUS_GENERATOR, options);
                 return -1;
             }
         } catch (ParseException e) {
-            formatter.printHelp("CorpusGenerator", options);
+            formatter.printHelp(CORPUS_GENERATOR, options);
         }
 
         boolean recurse = true;

--- a/core/src/main/java/com/digitalpebble/behemoth/util/CorpusReader.java
+++ b/core/src/main/java/com/digitalpebble/behemoth/util/CorpusReader.java
@@ -42,6 +42,8 @@ import com.digitalpebble.behemoth.DocumentFilter;
  **/
 public class CorpusReader extends Configured implements Tool {
 
+    private static final String CORPUS_READER = "CorpusReader";
+
     public static void main(String[] args) throws Exception {
         int res = ToolRunner.run(BehemothConfiguration.create(),
                 new CorpusReader(), args);
@@ -72,15 +74,15 @@ public class CorpusReader extends Configured implements Tool {
             line = parser.parse(options, args);
             String input = line.getOptionValue("i");
             if (line.hasOption("help")) {
-                formatter.printHelp("CorpusReader", options);
+                formatter.printHelp(CORPUS_READER, options);
                 return 0;
             }
             if (input == null) {
-                formatter.printHelp("CorpusReader", options);
+                formatter.printHelp(CORPUS_READER, options);
                 return -1;
             }
         } catch (ParseException e) {
-            formatter.printHelp("CorpusReader", options);
+            formatter.printHelp(CORPUS_READER, options);
             return -1;
         }
 

--- a/gate/src/main/java/com/digitalpebble/behemoth/gate/GATECorpusGenerator.java
+++ b/gate/src/main/java/com/digitalpebble/behemoth/gate/GATECorpusGenerator.java
@@ -57,6 +57,7 @@ public class GATECorpusGenerator extends Configured implements Tool {
 
     private static final Logger LOG = LoggerFactory
             .getLogger(GATECorpusGenerator.class);
+    private static final String GATE_CORPUS_GENERATOR = "GATECorpusGenerator";
 
     public GATECorpusGenerator() throws GateException {
         Gate.runInSandbox(true);
@@ -87,17 +88,17 @@ public class GATECorpusGenerator extends Configured implements Tool {
             String input = line.getOptionValue("i");
             String output = line.getOptionValue("o");
             if (line.hasOption("help")) {
-                formatter.printHelp("GATECorpusGenerator", options);
+                formatter.printHelp(GATE_CORPUS_GENERATOR, options);
                 return 0;
             }
             if (input == null || output == null) {
-                formatter.printHelp("GATECorpusGenerator", options);
+                formatter.printHelp(GATE_CORPUS_GENERATOR, options);
                 return -1;
             }
             generateXMLdocs(input, output);
 
         } catch (ParseException e) {
-            formatter.printHelp("GATECorpusGenerator", options);
+            formatter.printHelp(GATE_CORPUS_GENERATOR, options);
         }
         return 0;
     }

--- a/io/src/main/java/edu/cmu/lemurproject/WarcRecord.java
+++ b/io/src/main/java/edu/cmu/lemurproject/WarcRecord.java
@@ -63,6 +63,11 @@ import java.util.Set;
  * @author mhoy
  */
 public class WarcRecord {
+    private static final String CONTENT_LENGTH = "Content-Length";
+    private static final String WARC_TYPE = "WARC-Type";
+    private static final String WARC_DATE = "WARC-Date";
+    private static final String WARC_RECORD_ID = "WARC-Record-ID";
+    private static final String CONTENT_TYPE = "Content-Type";
 
     // public static final Log LOG = LogFactory.getLog(WarcRecord.class);
 
@@ -216,7 +221,7 @@ public class WarcRecord {
                 // find the content length designated by Content-Length:
                 // <length>
                 String[] parts = line.split(":", 2);
-                if (parts.length == 2 && parts[0].equals("Content-Length")) {
+                if (parts.length == 2 && parts[0].equals(CONTENT_LENGTH)) {
                     try {
                         contentLength = Integer.parseInt(parts[1].trim());
                         // LOG.info("WARC record content length: " +
@@ -300,15 +305,15 @@ public class WarcRecord {
             String thisValue = pieces[1].trim();
 
             // check for known keys
-            if (thisKey.equals("WARC-Type")) {
+            if (thisKey.equals(WARC_TYPE)) {
                 // LOG.info("Setting WARC record type: " + thisValue);
                 retRecord.setWarcRecordType(thisValue);
-            } else if (thisKey.equals("WARC-Date")) {
+            } else if (thisKey.equals(WARC_DATE)) {
                 retRecord.setWarcDate(thisValue);
-            } else if (thisKey.equals("WARC-Record-ID")) {
+            } else if (thisKey.equals(WARC_RECORD_ID)) {
                 // LOG.info("Setting WARC record ID: " + thisValue);
                 retRecord.setWarcUUID(thisValue);
-            } else if (thisKey.equals("Content-Type")) {
+            } else if (thisKey.equals(CONTENT_TYPE)) {
                 retRecord.setWarcContentType(thisValue);
             } else {
                 retRecord.addHeaderMetadata(thisKey, thisValue);
@@ -450,19 +455,19 @@ public class WarcRecord {
 
     public void addHeaderMetadata(String key, String value) {
         // don't allow addition of known keys
-        if (key.equals("WARC-Type")) {
+        if (key.equals(WARC_TYPE)) {
             return;
         }
-        if (key.equals("WARC-Date")) {
+        if (key.equals(WARC_DATE)) {
             return;
         }
-        if (key.equals("WARC-Record-ID")) {
+        if (key.equals(WARC_RECORD_ID)) {
             return;
         }
-        if (key.equals("Content-Type")) {
+        if (key.equals(CONTENT_TYPE)) {
             return;
         }
-        if (key.equals("Content-Length")) {
+        if (key.equals(CONTENT_LENGTH)) {
             return;
         }
 
@@ -479,19 +484,19 @@ public class WarcRecord {
 
     public String getHeaderMetadataItem(String key) {
 
-        if (key.equals("WARC-Type")) {
+        if (key.equals(WARC_TYPE)) {
             return warcHeader.recordType;
         }
-        if (key.equals("WARC-Date")) {
+        if (key.equals(WARC_DATE)) {
             return warcHeader.dateString;
         }
-        if (key.equals("WARC-Record-ID")) {
+        if (key.equals(WARC_RECORD_ID)) {
             return warcHeader.UUID;
         }
-        if (key.equals("Content-Type")) {
+        if (key.equals(CONTENT_TYPE)) {
             return warcHeader.contentType;
         }
-        if (key.equals("Content-Length")) {
+        if (key.equals(CONTENT_LENGTH)) {
             return Integer.toString(warcHeader.contentLength);
         }
 

--- a/language-id/src/main/java/com/digitalpebble/behemoth/languageidentification/LanguageIdDriver.java
+++ b/language-id/src/main/java/com/digitalpebble/behemoth/languageidentification/LanguageIdDriver.java
@@ -48,6 +48,7 @@ import com.digitalpebble.behemoth.BehemothReducer;
 import com.digitalpebble.behemoth.DocumentFilter;
 
 public class LanguageIdDriver extends Configured implements Tool {
+    private static final String LANGUAGE_ID_DRIVER = "LanguageIdDriver";
     private transient static Logger log = LoggerFactory
             .getLogger(LanguageIdDriver.class);
 
@@ -92,11 +93,11 @@ public class LanguageIdDriver extends Configured implements Tool {
             String input = cmdLine.getOptionValue("i");
             String output = cmdLine.getOptionValue("o");
             if (cmdLine.hasOption("help")) {
-                formatter.printHelp("LanguageIdDriver", options);
+                formatter.printHelp(LANGUAGE_ID_DRIVER, options);
                 return 0;
             }
             if (input == null | output == null) {
-                formatter.printHelp("LanguageIdDriver", options);
+                formatter.printHelp(LANGUAGE_ID_DRIVER, options);
                 return -1;
             }
             inputPath = new Path(input);
@@ -105,7 +106,7 @@ public class LanguageIdDriver extends Configured implements Tool {
                 overWrite = true;
             }
         } catch (ParseException e) {
-            formatter.printHelp("LanguageIdDriver", options);
+            formatter.printHelp(LANGUAGE_ID_DRIVER, options);
         }
 
         // check whether needs overwriting

--- a/mahout/src/main/java/com/digitalpebble/behemoth/mahout/BehemothDocumentProcessor.java
+++ b/mahout/src/main/java/com/digitalpebble/behemoth/mahout/BehemothDocumentProcessor.java
@@ -47,6 +47,10 @@ public final class BehemothDocumentProcessor {
     public static final String FEATURE_NAME = "Feature.name";
     public static final String ANALYZER_CLASS = "analyzer.class";
     public static final String MD_LABEL = "Metadata.Key.Label";
+    private static final String IO_SERIALIZATIONS = "io.serializations";
+    private static final String ORG_APACHE_HADOOP_IO_SERIALIZER_JAVA_SERIALIZATION = "org.apache.hadoop.io.serializer.JavaSerialization,";
+    private static final String ORG_APACHE_HADOOP_IO_SERIALIZER_WRITABLE_SERIALIZATION = "org.apache.hadoop.io.serializer.WritableSerialization";
+    private static final String JOB_FAILED = "Job failed!";
 
     // public static final Charset CHARSET = Charset.forName("UTF-8");
 
@@ -83,9 +87,9 @@ public final class BehemothDocumentProcessor {
         // this conf parameter needs to be set enable serialisation of conf
         // values
         conf.set(
-                "io.serializations",
-                "org.apache.hadoop.io.serializer.JavaSerialization,"
-                        + "org.apache.hadoop.io.serializer.WritableSerialization");
+                IO_SERIALIZATIONS,
+                ORG_APACHE_HADOOP_IO_SERIALIZER_JAVA_SERIALIZATION
+                        + ORG_APACHE_HADOOP_IO_SERIALIZER_WRITABLE_SERIALIZATION);
         conf.set(TOKEN_TYPE, type);
         conf.set(FEATURE_NAME, feature);
 
@@ -107,7 +111,7 @@ public final class BehemothDocumentProcessor {
 
         boolean succeeded = job.waitForCompletion(true);
         if (!succeeded)
-            throw new IllegalStateException("Job failed!");
+            throw new IllegalStateException(JOB_FAILED);
     }
 
     /**
@@ -132,9 +136,9 @@ public final class BehemothDocumentProcessor {
         // this conf parameter needs to be set enable serialisation of conf
         // values
         conf.set(
-                "io.serializations",
-                "org.apache.hadoop.io.serializer.JavaSerialization,"
-                        + "org.apache.hadoop.io.serializer.WritableSerialization");
+                IO_SERIALIZATIONS,
+                ORG_APACHE_HADOOP_IO_SERIALIZER_JAVA_SERIALIZATION
+                        + ORG_APACHE_HADOOP_IO_SERIALIZER_WRITABLE_SERIALIZATION);
         conf.set(ANALYZER_CLASS, analyzerClass.getName());
 
         Job job = new Job(conf);
@@ -155,7 +159,7 @@ public final class BehemothDocumentProcessor {
 
         boolean succeeded = job.waitForCompletion(true);
         if (!succeeded)
-            throw new IllegalStateException("Job failed!");
+            throw new IllegalStateException(JOB_FAILED);
 
     }
 
@@ -166,9 +170,9 @@ public final class BehemothDocumentProcessor {
         // this conf parameter needs to be set enable serialisation of conf
         // values
         conf.set(
-                "io.serializations",
-                "org.apache.hadoop.io.serializer.JavaSerialization,"
-                        + "org.apache.hadoop.io.serializer.WritableSerialization");
+                IO_SERIALIZATIONS,
+                ORG_APACHE_HADOOP_IO_SERIALIZER_JAVA_SERIALIZATION
+                        + ORG_APACHE_HADOOP_IO_SERIALIZER_WRITABLE_SERIALIZATION);
 
         Job job = new Job(conf);
         job.setJobName("DocumentProcessor::LabelDumper: input-folder: " + input);
@@ -187,7 +191,7 @@ public final class BehemothDocumentProcessor {
 
         boolean succeeded = job.waitForCompletion(true);
         if (!succeeded)
-            throw new IllegalStateException("Job failed!");
+            throw new IllegalStateException(JOB_FAILED);
 
     }
 

--- a/mahout/src/main/java/com/digitalpebble/behemoth/mahout/util/ClusterDocIDDumper.java
+++ b/mahout/src/main/java/com/digitalpebble/behemoth/mahout/util/ClusterDocIDDumper.java
@@ -58,6 +58,7 @@ import com.digitalpebble.behemoth.BehemothConfiguration;
 public class ClusterDocIDDumper extends Configured implements Tool,
         Mapper<IntWritable, WeightedVectorWritable, Text, Text> {
 
+    private static final String CLUSTER_DOC_ID_DUMPER = "ClusterDocIDDumper";
     @SuppressWarnings("unused")
     private transient static Logger log = LoggerFactory
             .getLogger(ClusterDocIDDumper.class);
@@ -90,15 +91,15 @@ public class ClusterDocIDDumper extends Configured implements Tool,
         try {
             line = parser.parse(options, args);
             if (line.hasOption("help")) {
-                formatter.printHelp("ClusterDocIDDumper", options);
+                formatter.printHelp(CLUSTER_DOC_ID_DUMPER, options);
                 return 0;
             }
             if (!line.hasOption("o") | !line.hasOption("i")) {
-                formatter.printHelp("ClusterDocIDDumper", options);
+                formatter.printHelp(CLUSTER_DOC_ID_DUMPER, options);
                 return -1;
             }
         } catch (ParseException e) {
-            formatter.printHelp("ClusterDocIDDumper", options);
+            formatter.printHelp(CLUSTER_DOC_ID_DUMPER, options);
         }
 
         Path inPath = new Path(line.getOptionValue("i"));
@@ -150,9 +151,9 @@ public class ClusterDocIDDumper extends Configured implements Tool,
             if (name != null & name.length() > 2)
                 output.collect(new Text(name), new Text(key.toString()));
             else
-                reporter.incrCounter("ClusterDocIDDumper", "Missing name", 1);
+                reporter.incrCounter(CLUSTER_DOC_ID_DUMPER, "Missing name", 1);
         } else
-            reporter.incrCounter("ClusterDocIDDumper", "Unnamed vector", 1);
+            reporter.incrCounter(CLUSTER_DOC_ID_DUMPER, "Unnamed vector", 1);
     }
 
 }

--- a/mahout/src/main/java/com/digitalpebble/behemoth/mahout/util/Mahout2LibSVM.java
+++ b/mahout/src/main/java/com/digitalpebble/behemoth/mahout/util/Mahout2LibSVM.java
@@ -71,6 +71,7 @@ public class Mahout2LibSVM extends Configured implements Tool,
         Reducer<Text, Text, Text, Text>,
         Mapper<Text, VectorWritable, Text, Text> {
 
+    private static final String CORPUS_GENERATOR = "CorpusGenerator";
     private transient static Logger log = LoggerFactory
             .getLogger(Mahout2LibSVM.class);
 
@@ -103,16 +104,16 @@ public class Mahout2LibSVM extends Configured implements Tool,
         try {
             line = parser.parse(options, args);
             if (line.hasOption("help")) {
-                formatter.printHelp("CorpusGenerator", options);
+                formatter.printHelp(CORPUS_GENERATOR, options);
                 return 0;
             }
             if (!line.hasOption("v") | !line.hasOption("o")
                     | !line.hasOption("l")) {
-                formatter.printHelp("CorpusGenerator", options);
+                formatter.printHelp(CORPUS_GENERATOR, options);
                 return -1;
             }
         } catch (ParseException e) {
-            formatter.printHelp("CorpusGenerator", options);
+            formatter.printHelp(CORPUS_GENERATOR, options);
         }
 
         Path vectorPath = new Path(line.getOptionValue("v"));


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1192 - String literals should not be duplicated.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1192
Please let me know if you have any questions.
George Kankava