### PR TITLE
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

### DIFF
--- a/core/src/main/java/com/digitalpebble/behemoth/Annotation.java
+++ b/core/src/main/java/com/digitalpebble/behemoth/Annotation.java
@@ -102,18 +102,18 @@ public class Annotation implements Comparable<Annotation> {
 
     /** Returns a String representation of the Annotation **/
     public String toString() {
-        StringBuffer buffer = new StringBuffer();
-        buffer.append(this.type).append("\t").append(start).append("\t")
+        StringBuilder builder = new StringBuilder();
+        builder.append(this.type).append("\t").append(start).append("\t")
                 .append(end);
         if (features != null) {
             Iterator<String> keysiter = features.keySet().iterator();
             while (keysiter.hasNext()) {
                 String key = keysiter.next();
                 String value = features.get(key).toString();
-                buffer.append("\t").append(key).append("=").append(value);
+                builder.append("\t").append(key).append("=").append(value);
             }
         }
-        return buffer.toString();
+        return builder.toString();
     }
 
 }

--- a/core/src/main/java/com/digitalpebble/behemoth/BehemothDocument.java
+++ b/core/src/main/java/com/digitalpebble/behemoth/BehemothDocument.java
@@ -325,41 +325,41 @@ public class BehemothDocument implements Writable {
      **/
     public String toString(boolean showContent, boolean showAnnotations,
             boolean showText, boolean showMD) {
-        StringBuffer buffer = new StringBuffer();
+        StringBuilder builder = new StringBuilder();
 
-        buffer.append("\nurl: ").append(url);
-        buffer.append("\ncontentType: ").append(contentType);
+        builder.append("\nurl: ").append(url);
+        builder.append("\ncontentType: ").append(contentType);
         if (metadata != null && showMD) {
-            buffer.append("\nmetadata: ");
+            builder.append("\nmetadata: ");
             for (Entry<Writable, Writable> e : metadata.entrySet()) {
-                buffer.append("\n\t");
-                buffer.append(e.getKey());
-                buffer.append(": ");
-                buffer.append(e.getValue());
+                builder.append("\n\t");
+                builder.append(e.getKey());
+                builder.append(": ");
+                builder.append(e.getValue());
             }
         }
         if (showContent) {
-            buffer.append("\nContent:\n");
+            builder.append("\nContent:\n");
             int maxLengthText = Math.min(200, content.length);
-            buffer.append(new String(Arrays.copyOfRange(content, 0,
+            builder.append(new String(Arrays.copyOfRange(content, 0,
                     maxLengthText)));
         }
         // try
         // default
         // encoding
         if (this.text != null && showText) {
-            buffer.append("\nText:\n");
+            builder.append("\nText:\n");
             int maxLengthText = Math.min(200, text.length());
-            buffer.append(text.substring(0, maxLengthText));
+            builder.append(text.substring(0, maxLengthText));
         }
         if (annotations == null || !showAnnotations)
-            return buffer.toString();
-        buffer.append("\nAnnotations:\n");
+            return builder.toString();
+        builder.append("\nAnnotations:\n");
         for (Annotation ann : annotations) {
-            buffer.append("\t").append(ann.toString()).append("\n");
+            builder.append("\t").append(ann.toString()).append("\n");
         }
 
-        return buffer.toString();
+        return builder.toString();
     }
 
 }

--- a/core/src/main/java/com/digitalpebble/behemoth/DocumentFilter.java
+++ b/core/src/main/java/com/digitalpebble/behemoth/DocumentFilter.java
@@ -112,7 +112,7 @@ public class DocumentFilter {
             String v = ent.getValue();
             k = k.substring(DocumentFilterParamNamePrefixKeep.length());
 
-            StringBuffer message = new StringBuffer();
+            StringBuilder message = new StringBuilder();
             if (filter.negativeMode)
                 message.append("Negative ");
             else

--- a/io/src/main/java/com/digitalpebble/behemoth/io/warc/HttpResponse.java
+++ b/io/src/main/java/com/digitalpebble/behemoth/io/warc/HttpResponse.java
@@ -43,7 +43,7 @@ public class HttpResponse {
         PushbackInputStream in = // process response
         new PushbackInputStream(new ByteArrayInputStream(response), BUFFER_SIZE);
 
-        StringBuffer line = new StringBuffer();
+        StringBuilder line = new StringBuilder();
 
         boolean haveSeenNonContinueStatus = false;
         while (!haveSeenNonContinueStatus) {
@@ -105,7 +105,7 @@ public class HttpResponse {
         content = out.toByteArray();
     }
 
-    private int parseStatusLine(PushbackInputStream in, StringBuffer line)
+    private int parseStatusLine(PushbackInputStream in, StringBuilder line)
             throws IOException {
         // skip first character if "\n"
         if (peek(in) == '\n') {
@@ -132,7 +132,7 @@ public class HttpResponse {
         return code;
     }
 
-    private void processHeaderLine(StringBuffer line) throws IOException {
+    private void processHeaderLine(StringBuilder line) throws IOException {
 
         int colonIndex = line.indexOf(":"); // key is up to colon
         if (colonIndex == -1) {
@@ -158,7 +158,7 @@ public class HttpResponse {
     }
 
     // Adds headers to our headers Metadata
-    private void parseHeaders(PushbackInputStream in, StringBuffer line)
+    private void parseHeaders(PushbackInputStream in, StringBuilder line)
             throws IOException {
 
         while (readLine(in, line, true) != 0) {
@@ -189,7 +189,7 @@ public class HttpResponse {
         }
     }
 
-    private static int readLine(PushbackInputStream in, StringBuffer line,
+    private static int readLine(PushbackInputStream in, StringBuilder line,
             boolean allowContinuedLine) throws IOException {
         line.setLength(0);
         for (int c = in.read(); c != -1; c = in.read()) {

--- a/io/src/main/java/edu/cmu/lemurproject/WarcHTMLResponseRecord.java
+++ b/io/src/main/java/edu/cmu/lemurproject/WarcHTMLResponseRecord.java
@@ -39,9 +39,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URISyntaxException;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Vector;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -64,7 +62,7 @@ public class WarcHTMLResponseRecord {
             .compile("^[hH][tT][tT][pP][sS]?://.*");
 
     // create our pattern set
-    private Vector<Pattern> patternSet = new Vector<Pattern>();
+    private List<Pattern> patternSet = new ArrayList<Pattern>();
 
     /**
      * Default constructor
@@ -142,7 +140,7 @@ public class WarcHTMLResponseRecord {
         return "";
     }
 
-    private HashSet<String> getMatchesOutputSet(Vector<String> tagSet,
+    private HashSet<String> getMatchesOutputSet(List<String> tagSet,
             String baseURL) {
         HashSet<String> retSet = new HashSet<String>();
 
@@ -179,8 +177,8 @@ public class WarcHTMLResponseRecord {
      * 
      * @return
      */
-    public Vector<String> getURLOutlinks() {
-        Vector<String> retVec = new Vector<String>();
+    public List<String> getURLOutlinks() {
+        List<String> retVec = new ArrayList<String>();
 
         String baseURL = getTargetURI();
         if ((baseURL == null) || (baseURL.length() == 0)) {
@@ -207,7 +205,7 @@ public class WarcHTMLResponseRecord {
             // now we have the rest of the lines
             // read them all into a string buffer
             // to remove all new lines
-            Vector<String> htmlTags = new Vector<String>();
+            List<String> htmlTags = new ArrayList<String>();
             while ((line = inReader.readLine()) != null) {
                 // get all HTML tags from the line...
                 Matcher HTMLMatcher = ALL_HTML_TAGS.matcher(line);

--- a/io/src/main/java/edu/cmu/lemurproject/WarcRecord.java
+++ b/io/src/main/java/edu/cmu/lemurproject/WarcRecord.java
@@ -173,7 +173,7 @@ public class WarcRecord {
     }
 
     private static byte[] readNextRecord(DataInputStream in,
-            StringBuffer headerBuffer) throws IOException {
+            StringBuilder headerBuffer) throws IOException {
         if (in == null) {
             return null;
         }
@@ -277,7 +277,7 @@ public class WarcRecord {
     public static WarcRecord readNextWarcRecord(DataInputStream in)
             throws IOException {
         // LOG.info("Starting read of WARC record");
-        StringBuffer recordHeader = new StringBuffer();
+        StringBuilder recordHeader = new StringBuilder();
         byte[] recordContent = readNextRecord(in, recordHeader);
         if (recordContent == null) {
             // LOG.info("WARC content is null - file is complete");
@@ -374,7 +374,7 @@ public class WarcRecord {
 
         @Override
         public String toString() {
-            StringBuffer retBuffer = new StringBuffer();
+            StringBuilder retBuffer = new StringBuilder();
 
             retBuffer.append(WARC_VERSION_LINE);
             retBuffer.append(LINE_ENDING);
@@ -535,7 +535,7 @@ public class WarcRecord {
 
     @Override
     public String toString() {
-        StringBuffer retBuffer = new StringBuffer();
+        StringBuilder retBuffer = new StringBuilder();
         retBuffer.append(warcHeader.toString());
         retBuffer.append(LINE_ENDING);
         retBuffer.append(new String(warcContent));

--- a/mahout/src/main/java/com/digitalpebble/behemoth/mahout/util/Mahout2LibSVM.java
+++ b/mahout/src/main/java/com/digitalpebble/behemoth/mahout/util/Mahout2LibSVM.java
@@ -272,7 +272,7 @@ public class Mahout2LibSVM extends Configured implements Tool,
             OutputCollector<Text, Text> output, Reporter reporter)
             throws IOException {
         Vector v = value.get();
-        StringBuffer buffer = new StringBuffer();
+        StringBuilder buffer = new StringBuilder();
         for (int i = 0; i < v.size(); i++) {
             Element el = v.getElement(i);
             int index = el.index();

--- a/tika/src/main/java/com/digitalpebble/behemoth/tika/TikaMarkupHandler.java
+++ b/tika/src/main/java/com/digitalpebble/behemoth/tika/TikaMarkupHandler.java
@@ -35,14 +35,14 @@ import com.digitalpebble.behemoth.Annotation;
 
 public class TikaMarkupHandler implements BehemothHandler {
 
-    private StringBuffer textBuffer;
+    private StringBuilder textBuffer;
 
     private List<Annotation> annotationBuffer;
 
     private LinkedList<Annotation> startedAnnotations;
 
     public TikaMarkupHandler() {
-        textBuffer = new StringBuffer();
+        textBuffer = new StringBuilder();
         annotationBuffer = new LinkedList<Annotation>();
         startedAnnotations = new LinkedList<Annotation>();
     }
@@ -53,7 +53,7 @@ public class TikaMarkupHandler implements BehemothHandler {
     }
 
     public void startDocument() throws SAXException {
-        textBuffer = new StringBuffer();
+        textBuffer = new StringBuilder();
         annotationBuffer = new LinkedList<Annotation>();
         startedAnnotations = new LinkedList<Annotation>();
     }

--- a/tika/src/main/java/com/digitalpebble/behemoth/tika/TikaProcessor.java
+++ b/tika/src/main/java/com/digitalpebble/behemoth/tika/TikaProcessor.java
@@ -278,7 +278,7 @@ public class TikaProcessor implements DocumentProcessor, TikaConstants {
             // at
             // org.apache.hadoop.io.AbstractMapWritable.readFields(AbstractMapWritable.java:204)
             // simply store multiple values as a , separated Text
-            StringBuffer buff = new StringBuffer();
+            StringBuilder buff = new StringBuilder();
             for (int i = 0; i < values.length; i++) {
                 if (i > 0)
                     buff.append(",");

--- a/tika/src/main/java/com/digitalpebble/behemoth/tika/TikaTextHandler.java
+++ b/tika/src/main/java/com/digitalpebble/behemoth/tika/TikaTextHandler.java
@@ -28,10 +28,10 @@ import com.digitalpebble.behemoth.Annotation;
 
 public class TikaTextHandler implements BehemothHandler {
 
-    private StringBuffer textBuffer;
+    private StringBuilder textBuffer;
 
     public TikaTextHandler() {
-        textBuffer = new StringBuffer();
+        textBuffer = new StringBuilder();
     }
 
     public void characters(char[] ch, int start, int length)
@@ -40,7 +40,7 @@ public class TikaTextHandler implements BehemothHandler {
     }
 
     public void startDocument() throws SAXException {
-        textBuffer = new StringBuffer();
+        textBuffer = new StringBuilder();
 
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1149
Please let me know if you have any questions.
George Kankava