### PR TITLE
Multiple code improvements - squid:S1213, squid:S1854, squid:S1118

### DIFF
--- a/core/src/main/java/com/digitalpebble/behemoth/util/AnnotationsUtil.java
+++ b/core/src/main/java/com/digitalpebble/behemoth/util/AnnotationsUtil.java
@@ -27,6 +27,9 @@ import com.digitalpebble.behemoth.Annotation;
 
 public class AnnotationsUtil {
 
+    private AnnotationsUtil() {
+    }
+
     /** Sort the annotations by startOffset **/
     public static void sort(List<Annotation> input) {
         Collections.sort(input, new AnnotationComparator());

--- a/core/src/main/java/com/digitalpebble/behemoth/util/ContentExtractor.java
+++ b/core/src/main/java/com/digitalpebble/behemoth/util/ContentExtractor.java
@@ -234,7 +234,7 @@ public class ContentExtractor extends Configured implements Tool {
                 else if (!dumpBinary && inputDoc.getText() == null)
                     continue;
 
-                String fileName = Integer.toString(count[0]);
+                String fileName;
                 String urldoc = inputDoc.getUrl();
                 if (mode.equals(FileNamingMode.URL) && urldoc != null
                         && urldoc.length() > 0) {

--- a/core/src/main/java/com/digitalpebble/behemoth/util/MimeUtil.java
+++ b/core/src/main/java/com/digitalpebble/behemoth/util/MimeUtil.java
@@ -19,6 +19,9 @@ package com.digitalpebble.behemoth.util;
 
 public final class MimeUtil {
 
+    private MimeUtil() {
+    }
+
     private static final String SEPARATOR = ";";
 
     /**

--- a/gate/src/main/java/com/digitalpebble/behemoth/gate/GATEProcessor.java
+++ b/gate/src/main/java/com/digitalpebble/behemoth/gate/GATEProcessor.java
@@ -301,7 +301,7 @@ public class GATEProcessor implements DocumentProcessor {
             throws ResourceInstantiationException, InvalidOffsetException,
             IOException {
 
-        gate.Document gatedocument = null;
+        gate.Document gatedocument;
 
         // if no text is available (e.g. Tika has not extracted it)
         // or want to re-parse with GATE

--- a/io/src/main/java/com/digitalpebble/behemoth/io/warc/WARCConverterJob.java
+++ b/io/src/main/java/com/digitalpebble/behemoth/io/warc/WARCConverterJob.java
@@ -58,6 +58,10 @@ public class WARCConverterJob extends Configured implements Tool,
 	public static final Logger LOG = LoggerFactory
 			.getLogger(WARCConverterJob.class);
 
+	private Text newKey = new Text();
+
+	private DocumentFilter filter;
+
 	public WARCConverterJob() {
 		this(null);
 	}
@@ -73,10 +77,6 @@ public class WARCConverterJob extends Configured implements Tool,
 
 	public void close() {
 	}
-
-	private Text newKey = new Text();
-
-	private DocumentFilter filter;
 
 	public void map(LongWritable key, WritableWarcRecord record,
 			OutputCollector<Text, BehemothDocument> output, Reporter reporter)

--- a/io/src/main/java/edu/cmu/lemurproject/WarcHTMLResponseRecord.java
+++ b/io/src/main/java/edu/cmu/lemurproject/WarcHTMLResponseRecord.java
@@ -195,7 +195,7 @@ public class WarcHTMLResponseRecord {
         // forward to the first \n\n
         try {
             boolean inHeader = true;
-            String line = null;
+            String line;
             while (inHeader && ((line = inReader.readLine()) != null)) {
                 if (line.trim().length() == 0) {
                     inHeader = false;

--- a/io/src/main/java/edu/cmu/lemurproject/WarcRecord.java
+++ b/io/src/main/java/edu/cmu/lemurproject/WarcRecord.java
@@ -97,7 +97,7 @@ public class WarcRecord {
         boolean keepReading = true;
         try {
             do {
-                char thisChar = 0;
+                char thisChar;
                 byte readByte = in.readByte();
                 // check to see if it's a multibyte character
                 if ((readByte & MASK_THREE_BYTE_CHAR) == MASK_THREE_BYTE_CHAR) {
@@ -186,9 +186,9 @@ public class WarcRecord {
             return null;
         }
 
-        String line = null;
+        String line;
         boolean foundMark = false;
-        byte[] retContent = null;
+        byte[] retContent;
 
         // cannot be using a buffered reader here!!!!
         // just read the header

--- a/language-id/src/main/java/com/digitalpebble/behemoth/languageidentification/LanguageIdProcessor.java
+++ b/language-id/src/main/java/com/digitalpebble/behemoth/languageidentification/LanguageIdProcessor.java
@@ -100,7 +100,7 @@ public class LanguageIdProcessor implements DocumentProcessor {
             return new BehemothDocument[] { inputDoc };
         }
 
-        String lang = null;
+        String lang;
 
         // skip docs with empty text
         if (inputDoc.getText().trim().isEmpty()) {

--- a/mahout/src/main/java/com/digitalpebble/behemoth/mahout/BehemothTokenizerMapper.java
+++ b/mahout/src/main/java/com/digitalpebble/behemoth/mahout/BehemothTokenizerMapper.java
@@ -51,7 +51,7 @@ public class BehemothTokenizerMapper extends
             if (features == null)
                 continue;
 
-            String featureValue = null;
+            String featureValue;
 
             // no feature? use the underlying text
             if (tokenFeature.equals("")) {

--- a/solr/src/main/java/com/digitalpebble/behemoth/solr/SOLRWriter.java
+++ b/solr/src/main/java/com/digitalpebble/behemoth/solr/SOLRWriter.java
@@ -245,7 +245,7 @@ public class SOLRWriter {
                     // iterate on the expected features
                     for (String targetFeature : featureField.keySet()) {
                         String SOLRFieldName = featureField.get(targetFeature);
-                        String value = null;
+                        String value;
                         // special case for covering text
                         if ("*".equals(targetFeature)) {
                             value = doc.getText().substring(


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S1854 - Dead stores should be removed.
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava